### PR TITLE
Fix GPU memory leak and sign shader duplication

### DIFF
--- a/src/main/java/com/github/sinfullysoul/block_entities/SignBlockEntity.java
+++ b/src/main/java/com/github/sinfullysoul/block_entities/SignBlockEntity.java
@@ -261,8 +261,6 @@ public class SignBlockEntity extends BlockEntity implements IRenderable {
         if (!shader.isCompiled()) {
             String log = SignBlockEntity.shader.getLog();
             throw new RuntimeException( "Sign Shader is not compiled!\n" + log);
-        } else {
-            System.out.println("SIGN SHADER COMPILED!!!!");
         }
     }
 }

--- a/src/main/java/com/github/sinfullysoul/mixins/GameShaderMixin.java
+++ b/src/main/java/com/github/sinfullysoul/mixins/GameShaderMixin.java
@@ -1,0 +1,19 @@
+package com.github.sinfullysoul.mixins;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.github.sinfullysoul.Constants;
+import com.github.sinfullysoul.block_entities.SignBlockEntity;
+import finalforeach.cosmicreach.rendering.shaders.GameShader;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GameShader.class)
+public abstract class GameShaderMixin {
+
+    @Inject(method = "initShaders", at = @At("TAIL"))
+    private static void createSignShader(CallbackInfo ci) {
+        SignBlockEntity.initSignShader();
+    }
+}

--- a/src/main/resources/cosmic-signs.mixins.json
+++ b/src/main/resources/cosmic-signs.mixins.json
@@ -8,7 +8,8 @@
     "ChunkMixin",
     "ControlsMixin",
     "InGameMixin",
-    "ZoneMixin"
+    "ZoneMixin",
+    "GameShaderMixin"
   ],
   "client": [],
   "server": [],


### PR DESCRIPTION
fixed shader, mesh, and FBO not being disposed when chunk was unloaded

each entity doesn't need its own shader. it was causing constant memory usage and garbage collection.

made sign shader init with the rest of the game shaders